### PR TITLE
Check session cookie in middleware and simplify public route handling

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,30 +1,29 @@
 import { NextResponse } from 'next/server'
-import { auth } from '@/lib/auth'
 
-const PUBLIC_ROUTES = [
-  '/',
-  '/tentang-kami',
-  '/why-free',
-  '/sign-in',
-  '/sign-up',
-  '/api/webhooks',
-  '/api/auth'
-]
+const PUBLIC_EXACT_ROUTES = ['/', '/tentang-kami', '/why-free', '/sign-in', '/sign-up']
+const PUBLIC_PREFIX_ROUTES = ['/api/webhooks', '/api/auth']
 
-export default async function middleware(req) {
-  const pathname = req.nextUrl.pathname
-  const isPublicRoute = PUBLIC_ROUTES.some(route => pathname.startsWith(route))
-
-  const session = await auth.api.getSession({
-    headers: req.headers
-  })
-
-  if (!session && !isPublicRoute) {
-    return NextResponse.redirect(new URL('/sign-in', req.url))
+function isPublicRoute(pathname) {
+  if (PUBLIC_EXACT_ROUTES.includes(pathname)) {
+    return true
   }
 
-  if (session?.user && pathname === '/onboarding') {
-    return NextResponse.next()
+  return PUBLIC_PREFIX_ROUTES.some(
+    route => pathname === route || pathname.startsWith(`${route}/`)
+  )
+}
+
+function hasSessionCookie(req) {
+  return req.cookies
+    .getAll()
+    .some(({ name }) => name.includes('better-auth') && name.includes('session_token'))
+}
+
+export default function middleware(req) {
+  const pathname = req.nextUrl.pathname
+
+  if (!hasSessionCookie(req) && !isPublicRoute(pathname)) {
+    return NextResponse.redirect(new URL('/sign-in', req.url))
   }
 
   return NextResponse.next()


### PR DESCRIPTION
### Motivation
- Avoid an async round-trip to the auth API on every request by using a cookie-based session presence check in middleware to improve performance and reliability.
- Make public routes handling clearer by separating exact routes from prefix-based API routes.
- Simplify middleware logic and remove the special-case onboarding flow.

### Description
- Removed the `auth` import and the async `auth.api.getSession` usage and replaced it with a synchronous cookie check implemented in `hasSessionCookie(req)`.
- Replaced a single `PUBLIC_ROUTES` list with `PUBLIC_EXACT_ROUTES` and `PUBLIC_PREFIX_ROUTES` and added `isPublicRoute(pathname)` to handle exact and prefix matches.
- Middleware now returns early with a redirect to `/sign-in` when `hasSessionCookie` is false and `isPublicRoute` is false, otherwise it calls `NextResponse.next()`.
- Removed the onboarding-specific session handling and converted the middleware to a synchronous implementation while preserving the existing `config.matcher`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4854093488330a8ce02a856f9fa99)